### PR TITLE
Fix newline at EOF

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ google-adk>=0.1.0
 requests>=2.31.0
 pandas>=2.0.0
 python-dotenv>=1.0.0
-pydeck>=0.8.0 
+pydeck>=0.8.0

--- a/secrets_utils.py
+++ b/secrets_utils.py
@@ -15,20 +15,20 @@ except ImportError:
 def get_secret(key: str, default: str = None) -> str:
     """
     Get secret from Streamlit secrets manager or environment variables
-    
+
     Args:
         key: The secret key to retrieve
         default: Default value if key not found
-        
+
     Returns:
         The secret value or default
     """
-    
+
     # First try environment variables (works for both local and some cloud setups)
     env_value = os.getenv(key)
     if env_value and not env_value.startswith('YOUR_') and len(env_value) > 10:
         return env_value
-    
+
     # Try Streamlit secrets (for Streamlit Cloud deployment)
     try:
         import streamlit as st
@@ -38,5 +38,5 @@ def get_secret(key: str, default: str = None) -> str:
                 return streamlit_value
     except:
         pass  # Streamlit not available or no secrets
-    
-    return default 
+
+    return default


### PR DESCRIPTION
## Summary
- add newline to `secrets_utils.py`
- strip trailing space and newline-terminate `requirements.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a36c3c4848331a89866da1eb4c2a4