### PR TITLE
Add travel cost unit test

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -95,3 +95,10 @@ def test_execute_workflow_returns_dict(monkeypatch):
     assert isinstance(result, dict)
     assert result['status'] == 'success'
     assert 'advisor_response' in result
+
+
+def test_calculate_travel_costs():
+    result = agents.calculate_travel_costs(1609, 3600)
+    assert result['gas_cost'] == 0.14
+    assert result['time_hours'] == 1.0
+    assert result['total_travel_cost'] == 20.14


### PR DESCRIPTION
## Summary
- add a unit test for `calculate_travel_costs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a36c7b4488331bfbf625ec9ab2360